### PR TITLE
feat: add data import and export functionality

### DIFF
--- a/src-tauri/src/data_model/episode.rs
+++ b/src-tauri/src/data_model/episode.rs
@@ -2,7 +2,7 @@ use super::{IdType, media_file::MediaFile};
 use itertools::Itertools;
 use std::path::PathBuf;
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Episode {
     pub id: IdType,
     pub number: i32,

--- a/src-tauri/src/data_model/imdb.rs
+++ b/src-tauri/src/data_model/imdb.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Imdb {
     pub imdb_id: String,
     pub r#type: String,
@@ -15,7 +15,7 @@ pub struct Imdb {
     pub directors: Vec<Person>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Person {
     pub id: String,
     pub name: String,

--- a/src-tauri/src/data_model/media.rs
+++ b/src-tauri/src/data_model/media.rs
@@ -3,7 +3,7 @@ use itertools::Itertools;
 use regex::Regex;
 use std::path::PathBuf;
 
-#[derive(Debug, Clone, Default, Eq, serde::Serialize)]
+#[derive(Debug, Clone, Default, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Media {
     pub id: IdType,
     pub name: String,

--- a/src-tauri/src/data_model/season.rs
+++ b/src-tauri/src/data_model/season.rs
@@ -3,7 +3,7 @@ use itertools::Itertools;
 use regex::Regex;
 use std::path::PathBuf;
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Season {
     pub id: IdType,
     pub number: i32,

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -104,4 +104,6 @@ pub trait DB {
     fn insert_tag(&self, tag: &Tag) -> Result<()>;
     fn insert_media_tag(&self, media_id: IdType, tag_id: IdType) -> Result<()>;
     fn remove_media_tag(&self, media_id: IdType, tag_id: IdType) -> Result<()>;
+    fn get_all_medias(&self) -> Result<Vec<Media>>;
+    fn import_data(&self, data: &crate::ExportedData) -> Result<()>;
 }

--- a/src-tauri/src/db/moke.rs
+++ b/src-tauri/src/db/moke.rs
@@ -115,4 +115,12 @@ impl DB for MokeDB {
     fn remove_media_tag(&self, _media_id: IdType, _tag_id: IdType) -> Result<()> {
         todo!()
     }
+
+    fn get_all_medias(&self) -> Result<Vec<Media>> {
+        todo!()
+    }
+
+    fn import_data(&self, _data: &crate::ExportedData) -> Result<()> {
+        todo!()
+    }
 }

--- a/src-tauri/src/db/sqlite.rs
+++ b/src-tauri/src/db/sqlite.rs
@@ -1192,9 +1192,7 @@ impl DB for Sqlite {
 
     fn get_all_medias(&self) -> Result<Vec<Media>> {
         let conn = &mut self.get_conn()?;
-        let media_ids = medias::table
-            .select(medias::id)
-            .load::<i32>(conn)?;
+        let media_ids = medias::table.select(medias::id).load::<i32>(conn)?;
 
         let medias = media_ids
             .into_iter()

--- a/src-tauri/src/db/sqlite.rs
+++ b/src-tauri/src/db/sqlite.rs
@@ -1189,4 +1189,39 @@ impl DB for Sqlite {
         .execute(conn)?;
         Ok(())
     }
+
+    fn get_all_medias(&self) -> Result<Vec<Media>> {
+        let conn = &mut self.get_conn()?;
+        let media_ids = medias::table
+            .select(medias::id)
+            .load::<i32>(conn)?;
+
+        let medias = media_ids
+            .into_iter()
+            .map(|id| Self::get_media_by_id(conn, id))
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+
+        Ok(medias)
+    }
+
+    fn import_data(&self, data: &crate::ExportedData) -> Result<()> {
+        self.get_conn()?.transaction(|conn| {
+            // Insert tags first
+            for tag in &data.tags {
+                diesel::insert_or_ignore_into(tags::table)
+                    .values(&NewTag { name: &tag.name })
+                    .execute(conn)?;
+            }
+
+            // Insert medias
+            for media in &data.medias {
+                Self::insert_media(conn, media)?;
+            }
+
+            Ok(())
+        })
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,12 @@ use crate::{
     db::{DB, FilterValues},
 };
 
+#[derive(serde::Serialize, serde::Deserialize)]
+struct ExportedData {
+    medias: Vec<Media>,
+    tags: Vec<Tag>,
+}
+
 mod data_model;
 mod db;
 mod fetch_imdb;
@@ -265,6 +271,30 @@ fn delete_media(media_id: IdType, state: tauri::State<'_, AppState>) -> Result<(
     db.delete_media(media_id).map_err(|e| e.to_string())
 }
 
+#[tauri::command]
+async fn export_data(file_path: String, state: tauri::State<'_, AppState>) -> Result<(), String> {
+    use std::fs;
+
+    let db = &state.db;
+
+    let medias = db.get_all_medias().map_err(|e| e.to_string())?;
+    let tags = db.get_tags().map_err(|e| e.to_string())?;
+
+    let data = ExportedData { medias, tags };
+    let json = serde_json::to_string(&data).map_err(|e| e.to_string())?;
+
+    fs::write(&file_path, json).map_err(|e| format!("Failed to write file: {}", e))?;
+
+    Ok(())
+}
+
+#[tauri::command]
+fn import_data(data: String, state: tauri::State<'_, AppState>) -> Result<(), String> {
+    let db = &state.db;
+    let exported: ExportedData = serde_json::from_str(&data).map_err(|e| e.to_string())?;
+    db.import_data(&exported).map_err(|e| e.to_string())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -295,7 +325,9 @@ pub fn run() {
             insert_tag,
             insert_media_tag,
             remove_media_tag,
-            delete_media
+            delete_media,
+            export_data,
+            import_data
         ])
         .setup(|app| {
             let db = Sqlite::from_app_handle(app.app_handle())?;

--- a/src/component/media_page/FileRow.vue
+++ b/src/component/media_page/FileRow.vue
@@ -77,10 +77,10 @@ import type { File } from '../../type'
 import { Files, FolderOpen, Play, Scissors, Trash2 } from 'lucide-vue-next'
 
 // --- Tauri APIs (rename copyFile import to avoid collision with local function) ---
-import { basename, dirname, join } from '@tauri-apps/api/path'
+import { basename, dirname } from '@tauri-apps/api/path'
 import { openPath } from '@tauri-apps/plugin-opener'
 import { copyFile as fsCopyFile, rename, remove } from '@tauri-apps/plugin-fs'
-import { open } from '@tauri-apps/plugin-dialog'
+import { save } from '@tauri-apps/plugin-dialog'
 import { writeText } from '@tauri-apps/plugin-clipboard-manager'
 
 // --- Utilities ---
@@ -108,58 +108,80 @@ async function openFileLocation() {
   }
 }
 
-// --- Function: Move the file to a selected directory ---
+// --- Function: Move the file to a selected location ---
 async function moveFile() {
   try {
-    const targetDir = await open({
-      directory: true,
-      multiple: false,
-      title: 'Select target dir',
-    })
-    if (!targetDir) return
-
     const fileName = await basename(filePath)
-    const targetPath = await join(targetDir, fileName)
 
-    toast.info('Move started...')
+    const targetPath = await save({
+      defaultPath: fileName,
+      title: 'Select target location for file move',
+    })
+
+    if (!targetPath) return
+
+    // Prevent moving to the same location
+    if (targetPath === filePath) {
+      toast.warning('Source and destination are the same')
+      return
+    }
+
+    toast.info('Moving file...')
+
     try {
       await rename(filePath, targetPath)
     } catch (err: unknown) {
-      // Fallback for cross-device move
-      if (String(err).includes('Invalid cross-device link')) {
+      const errorMessage = String(err)
+      // Handle cross-device moves (different filesystems/drives)
+      if (
+        errorMessage.includes('Invalid cross-device link') ||
+        errorMessage.includes('cross-device') ||
+        errorMessage.includes('EXDEV')
+      ) {
+        // Copy then delete for cross-device moves
         await fsCopyFile(filePath, targetPath)
         await remove(filePath)
       } else {
         throw err
       }
     }
+
     toast.success('File moved successfully')
     emit('reload')
   } catch (e) {
-    toast.error('Move failed!')
-    console.error('Error moving file:', e)
+    const error = e as Error
+    toast.error(`Move failed: ${error.message || 'Unknown error'}`)
+    console.error('Error moving file:', error)
   }
 }
 
-// --- Function: Copy the file to a selected directory ---
+// --- Function: Copy the file to a selected location ---
 async function copyFile() {
   try {
-    const targetDir = await open({
-      directory: true,
-      multiple: false,
-      title: 'Select target folder',
-    })
-    if (!targetDir) return
-
     const fileName = await basename(filePath)
-    const targetPath = await join(targetDir, fileName)
 
-    toast.info('Copy started...')
+    const targetPath = await save({
+      defaultPath: fileName,
+      title: 'Select target location for file copy',
+    })
+
+    if (!targetPath) return
+
+    // Prevent copying to the same location
+    if (targetPath === filePath) {
+      toast.warning('Source and destination are the same')
+      return
+    }
+
+    toast.info('Copying file...')
+
     await fsCopyFile(filePath, targetPath)
+
     toast.success('File copied successfully')
   } catch (e) {
-    toast.error('Copy failed!')
-    console.error('Error copying file:', e)
+    const error = e as Error
+    toast.error(`Copy failed: ${error.message || 'Unknown error'}`)
+    console.error('Error copying file:', error)
   }
 }
 

--- a/src/pages/SettingPage.vue
+++ b/src/pages/SettingPage.vue
@@ -41,12 +41,13 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
-import { TagsIcon, PaletteIcon, FolderIcon } from 'lucide-vue-next'
+import { TagsIcon, PaletteIcon, FolderIcon, DatabaseIcon } from 'lucide-vue-next'
 
 // List of settings categories with their icons and routes
 const categories = ref([
   { name: 'Tag', icon: TagsIcon, route: 'tags_setting' },
   { name: 'Appearance', icon: PaletteIcon, route: 'appearance_setting' },
   { name: 'Directories', icon: FolderIcon, route: 'directories_setting' },
+  { name: 'Data', icon: DatabaseIcon, route: 'data_setting' },
 ])
 </script>

--- a/src/pages/settings/DataSetting.vue
+++ b/src/pages/settings/DataSetting.vue
@@ -3,30 +3,22 @@
     <h2 class="card-title mb-4">Data Management</h2>
     <div class="space-y-4">
       <div class="card bg-base-100 p-4">
-        <h3 class="text-lg font-semibold mb-2">Export Data</h3>
-        <p class="text-sm text-base-content/70 mb-4">
+        <h3 class="mb-2 text-lg font-semibold">Export Data</h3>
+        <p class="text-base-content/70 mb-4 text-sm">
           Export all your movie data to a JSON file for backup or transfer.
         </p>
-        <button
-          class="btn btn-primary"
-          @click="exportData"
-          :disabled="isExporting"
-        >
+        <button class="btn btn-primary" @click="exportData" :disabled="isExporting">
           <span v-if="isExporting" class="loading loading-spinner loading-sm"></span>
           {{ isExporting ? 'Exporting...' : 'Export Data' }}
         </button>
       </div>
 
       <div class="card bg-base-100 p-4">
-        <h3 class="text-lg font-semibold mb-2">Import Data</h3>
-        <p class="text-sm text-base-content/70 mb-4">
+        <h3 class="mb-2 text-lg font-semibold">Import Data</h3>
+        <p class="text-base-content/70 mb-4 text-sm">
           Import movie data from a previously exported JSON file. This will merge with existing data.
         </p>
-        <button
-          class="btn btn-secondary"
-          @click="importData"
-          :disabled="isImporting"
-        >
+        <button class="btn btn-secondary" @click="importData" :disabled="isImporting">
           <span v-if="isImporting" class="loading loading-spinner loading-sm"></span>
           {{ isImporting ? 'Importing...' : 'Import Data' }}
         </button>
@@ -49,11 +41,13 @@ const exportData = async () => {
   try {
     // Open save dialog
     const filePath = await save({
-      filters: [{
-        name: 'JSON',
-        extensions: ['json']
-      }],
-      defaultPath: `movie-vault-data-${new Date().toISOString().split('T')[0]}.json`
+      filters: [
+        {
+          name: 'JSON',
+          extensions: ['json'],
+        },
+      ],
+      defaultPath: `movie-vault-data-${new Date().toISOString().split('T')[0]}.json`,
     })
 
     if (!filePath) {
@@ -73,16 +67,17 @@ const exportData = async () => {
   }
 }
 
-
 const importData = async () => {
   try {
     // Open file dialog
     const filePath = await open({
       multiple: false,
-      filters: [{
-        name: 'JSON',
-        extensions: ['json']
-      }]
+      filters: [
+        {
+          name: 'JSON',
+          extensions: ['json'],
+        },
+      ],
     })
 
     if (!filePath || Array.isArray(filePath)) {

--- a/src/pages/settings/DataSetting.vue
+++ b/src/pages/settings/DataSetting.vue
@@ -1,0 +1,108 @@
+<template>
+  <div class="card bg-base-200 p-6">
+    <h2 class="card-title mb-4">Data Management</h2>
+    <div class="space-y-4">
+      <div class="card bg-base-100 p-4">
+        <h3 class="text-lg font-semibold mb-2">Export Data</h3>
+        <p class="text-sm text-base-content/70 mb-4">
+          Export all your movie data to a JSON file for backup or transfer.
+        </p>
+        <button
+          class="btn btn-primary"
+          @click="exportData"
+          :disabled="isExporting"
+        >
+          <span v-if="isExporting" class="loading loading-spinner loading-sm"></span>
+          {{ isExporting ? 'Exporting...' : 'Export Data' }}
+        </button>
+      </div>
+
+      <div class="card bg-base-100 p-4">
+        <h3 class="text-lg font-semibold mb-2">Import Data</h3>
+        <p class="text-sm text-base-content/70 mb-4">
+          Import movie data from a previously exported JSON file. This will merge with existing data.
+        </p>
+        <button
+          class="btn btn-secondary"
+          @click="importData"
+          :disabled="isImporting"
+        >
+          <span v-if="isImporting" class="loading loading-spinner loading-sm"></span>
+          {{ isImporting ? 'Importing...' : 'Import Data' }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { invoke } from '@tauri-apps/api/core'
+import { save, open } from '@tauri-apps/plugin-dialog'
+import { readTextFile } from '@tauri-apps/plugin-fs'
+import { toast } from 'vue3-toastify'
+
+const isExporting = ref(false)
+const isImporting = ref(false)
+
+const exportData = async () => {
+  try {
+    // Open save dialog
+    const filePath = await save({
+      filters: [{
+        name: 'JSON',
+        extensions: ['json']
+      }],
+      defaultPath: `movie-vault-data-${new Date().toISOString().split('T')[0]}.json`
+    })
+
+    if (!filePath) {
+      return // User cancelled
+    }
+
+    isExporting.value = true
+
+    await invoke('export_data', { filePath })
+
+    toast.success('Export completed successfully!')
+  } catch (error) {
+    console.error('Export failed:', error)
+    toast.error('Export failed: ' + error)
+  } finally {
+    isExporting.value = false
+  }
+}
+
+
+const importData = async () => {
+  try {
+    // Open file dialog
+    const filePath = await open({
+      multiple: false,
+      filters: [{
+        name: 'JSON',
+        extensions: ['json']
+      }]
+    })
+
+    if (!filePath || Array.isArray(filePath)) {
+      return // User cancelled or selected multiple files
+    }
+
+    isImporting.value = true
+
+    // Read file content
+    const text = await readTextFile(filePath)
+
+    // Import data
+    await invoke('import_data', { data: text })
+
+    alert('Data imported successfully!')
+  } catch (error) {
+    console.error('Import failed:', error)
+    alert('Import failed: ' + error)
+  } finally {
+    isImporting.value = false
+  }
+}
+</script>

--- a/src/router.ts
+++ b/src/router.ts
@@ -9,6 +9,7 @@ const settingChildren: RouteRecordRaw[] = [
     component: () => import('./pages/settings/DirectorySetting.vue'),
     name: 'directories_setting',
   },
+  { path: 'data', component: () => import('./pages/settings/DataSetting.vue'), name: 'data_setting' },
 ]
 
 const routes: RouteRecordRaw[] = [


### PR DESCRIPTION
Add support for exporting all media and tags to a JSON file and importing them back into the database. This includes new Tauri commands for export and import, database trait methods, and a new settings page for data management. All data model structs now derive Deserialize for serialization support.
